### PR TITLE
Fix to match tree(1) closer.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function tre(files = [], opts = {}) {
         const isLast = index === actualFiles.length - 1
         const next = actualFiles[index + 1]
         const char =
-          next && next.depth === item.depth ? CHARS.continue : CHARS.end
+          next && next.depth >= item.depth ? CHARS.continue : CHARS.end
         const linePrefix = item.depth > 0 && !isLast ? CHARS.line : ''
         const prefix = `${linePrefix}${repeat(
           ' ',


### PR DESCRIPTION
Before, it outputs

```patch
 test
 ├── readme.md
 ├── package.json
-└── lib
 │   └── test.js
 └── .gitignore
```

With this change it outputs

```patch
 test
 ├── readme.md
 ├── package.json
+├── lib
 │   └── test.js
 └── .gitignore
```

This matches the `tree(1)` command a bit closer.